### PR TITLE
Varnish 4 support + p.wait() removed

### DIFF
--- a/varnish/stats.py
+++ b/varnish/stats.py
@@ -69,13 +69,13 @@ class VarnishstatMonitor (threading.Thread):
         # We need to calculate a few metrics from the raw data.
         try:
             self.metrics['cache_hit_ratio'].update(
-                (self.metrics['cache_hit'].value*1.0)/self.metrics['cache_miss'].value)
+                (self.metrics['MAIN.cache_hit'].value*1.0)/self.metrics['MAIN.cache_miss'].value)
         except ZeroDivisionError:
             self.metrics['cache_hit_ratio'].update(0)
 
         try:
             self.metrics['cache_hit_pct'].update(
-                (self.metrics['cache_hit'].value*1.0)/self.metrics['client_req'].value * 100)
+                (self.metrics['MAIN.cache_hit'].value*1.0)/self.metrics['MAIN.client_req'].value * 100)
         except ZeroDivisionError:
             self.metrics['cache_hit_pct'].update(0)
 

--- a/varnish/varnishstat.py
+++ b/varnish/varnishstat.py
@@ -27,9 +27,8 @@ class Varnishstat (object):
 
         p = subprocess.Popen([self.vspath, '-1'],
             stdout=subprocess.PIPE)
-        p.wait()
 
-        for line in p.stdout:
+        for line in iter(p.stdout.readline, b''):
             name, val, avg, desc = line.strip().split(None, 3)
             if name in forced_metrics:
                 m.append((name, desc, forced_metrics[name]))
@@ -37,6 +36,8 @@ class Varnishstat (object):
                 m.append((name, desc, m_count))
             else:
                 m.append((name, desc, m_rate))
+
+        p.communicate()
 
         return m
 
@@ -46,9 +47,9 @@ class Varnishstat (object):
 
         p = subprocess.Popen([self.vspath, '-1', '-x'],
             stdout=subprocess.PIPE)
-        p.wait()
+        output = p.communicate()[0]
 
-        doc = lxml.etree.fromstring(p.stdout.read())
+        doc = lxml.etree.fromstring(output)
         for stat in doc.xpath('/varnishstat/stat'):
             name = stat.xpath('name')[0].text
             value = stat.xpath('value')[0].text


### PR DESCRIPTION
p.wait() - https://docs.python.org/2/library/subprocess.html#subprocess.Popen.wait

"Warning This will deadlock when using stdout=PIPE and/or stderr=PIPE and the child process generates enough output to a pipe such that it blocks waiting for the OS pipe buffer to accept more data. Use communicate() to avoid that."

Replaced with p.communicate()

Additional few changes for Varnish 4 and correct metrics names
