### PR TITLE
Exception

### DIFF
--- a/varnish/varnishstat.py
+++ b/varnish/varnishstat.py
@@ -51,9 +51,12 @@ class Varnishstat (object):
 
         doc = json.loads(output)
         for stat in doc:
-            name = stat
-            value = doc[stat]["value"]
-            yield(name, int(value))
+            try:
+                name = stat
+                value = doc[stat]["value"]
+                yield(name, int(value))
+            except:
+                continue
 
 if __name__ == '__main__':
 

--- a/varnish/varnishstat.py
+++ b/varnish/varnishstat.py
@@ -1,5 +1,5 @@
 import subprocess
-import lxml.etree
+import json
 
 import metrics
 
@@ -42,22 +42,22 @@ class Varnishstat (object):
         return m
 
     def read_metrics(self):
-        '''Read XML output from varnishstat and parse it 
-        with lxml.etree.'''
+        '''Read JSON output from varnishstat and parse it 
+        with json.'''
 
-        p = subprocess.Popen([self.vspath, '-1', '-x'],
+        p = subprocess.Popen([self.vspath, '-1', '-j'],
             stdout=subprocess.PIPE)
         output = p.communicate()[0]
 
-        doc = lxml.etree.fromstring(output)
-        for stat in doc.xpath('/varnishstat/stat'):
-            name = stat.xpath('name')[0].text
-            value = stat.xpath('value')[0].text
+        doc = json.loads(output)
+        for stat in doc:
+            name = stat
+            value = doc[stat]["value"]
             yield(name, int(value))
 
 if __name__ == '__main__':
 
-    v = VarnishStat()
+    v = Varnishstat()
 
 # vim: set ts=4 sw=4 expandtab ai :
 


### PR DESCRIPTION
Output JSON from varnishstat contain some entries we don't need in ganglia plugin. This fix should avoid exception:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 551, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/dist-packages/varnish/stats.py", line 86, in run
    self.update_metrics()
  File "/usr/lib/python2.7/dist-packages/varnish/stats.py", line 65, in update_metrics
    for name, value in self.varnishstat.read_metrics():
  File "/usr/lib/python2.7/dist-packages/varnish/varnishstat.py", line 55, in read_metrics
    value = doc[stat]["value"]
TypeError: string indices must be integers
```
